### PR TITLE
Added bash script for auto-annotate no-morph files

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,5 @@
+# Data processing scripts
+
+To add automatic annotation to files not having morphosyntactic annotation (in `no-morph` directories), run the following commands:
+1. `cp -R data annotated-data`
+1. `find data/genres/ -wholename "*/no-morph/*.conllup" | xargs -I@ -n 1 ./scripts/annotate.sh @ annotated-@`

--- a/scripts/annotate.sh
+++ b/scripts/annotate.sh
@@ -4,16 +4,16 @@ VERSION="4.0.6"
 
 input_file=$1
 output_file=$2``
-tmp_file=/tmp/emtsv/$(basename "$input_file")
+tmp_file=./tmp/emtsv/$(basename "$input_file")
 
 echo "Processing \"$input_file\""
-mkdir -p /tmp/emtsv
+mkdir -p ./tmp/emtsv
 
 # Store emtsv results in a temp file
 awk 'BEGIN {print "form"} {print}' "${input_file}" \
   | grep -v "^#" \
   | cut -f 1 \
-  | docker run --rm -i mtaril/emtsv:${VERSION} emMorph,emTag,emmorph2ud 2>/dev/null \
+  | docker run --rm -i mtaril/emtsv:${VERSION} emMorph,emTag,emmorph2ud 2>>error.log \
   | awk -F $'\t' 'BEGIN {OFS = FS} FNR>1 {print $3,$5,$4,$6}' > "$tmp_file"
 
 # Merge the original file w/ the emtsv result

--- a/scripts/annotate.sh
+++ b/scripts/annotate.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+VERSION="4.0.6"
+
+input_file=$1
+output_file=$2``
+tmp_file=/tmp/emtsv/$(basename "$input_file")
+
+echo "Processing \"$input_file\""
+mkdir -p /tmp/emtsv
+
+# Store emtsv results in a temp file
+awk 'BEGIN {print "form"} {print}' "${input_file}" \
+  | grep -v "^#" \
+  | cut -f 1 \
+  | docker run --rm -i mtaril/emtsv:${VERSION} emMorph,emTag,emmorph2ud 2>/dev/null \
+  | awk -F $'\t' 'BEGIN {OFS = FS} FNR>1 {print $3,$5,$4,$6}' > "$tmp_file"
+
+# Merge the original file w/ the emtsv result
+paste <(grep -v "^#" "$input_file" | cut -f 1) \
+      <(grep -v "^#" "$tmp_file") \
+      <(grep -v "^#" "$input_file" | cut -f 6) \
+  | awk 'BEGIN {print "# global.columns = FORM LEMMA UPOS XPOS FEATS CONLL:NER"} {print}' \
+  > "$output_file"
+
+rm "$tmp_file"

--- a/scripts/annotate.sh
+++ b/scripts/annotate.sh
@@ -3,7 +3,7 @@
 VERSION="4.0.6"
 
 input_file=$1
-output_file=$2``
+output_file=$2
 tmp_file=./tmp/emtsv/$(basename "$input_file")
 
 echo "Processing \"$input_file\""


### PR DESCRIPTION
# Summary

Added `scripts/annotate.sh` for annotating `conllup` files with morpho-syntactic information. The script keeps the original tokenization and uses `emtsv` to produce PoS tags, lemmata and additional morpho-syntactic labels.