### PR TITLE
Fixed IOB labels for "Urál-hegységben"

### DIFF
--- a/data/genres/wikipedia/morph/huwiki_47.conllup
+++ b/data/genres/wikipedia/morph/huwiki_47.conllup
@@ -373,8 +373,8 @@ csiszolnak	csiszol	VERB	[/V][Prs.NDef.3Pl]	Definite=Ind|Mood=Ind|Number=Plur|Per
 .	.	PUNCT	[Punct]	_	O
 
 Az	az	DET	[/Det|Art.Def]	Definite=Def|PronType=Art	O
-Urál	Urál	PROPN	[/N][Nom]	Case=Nom|Number=Sing	I-LOC
-hegységben	hegység	NOUN	[/N][Ine]	Case=Ine|Number=Sing	B-LOC
+Urál	Urál	PROPN	[/N][Nom]	Case=Nom|Number=Sing	B-LOC
+hegységben	hegység	NOUN	[/N][Ine]	Case=Ine|Number=Sing	I-LOC
 is	is	ADV	[/Adv]	_	O
 találhatók	található	ADJ	[/Adj][Pl][Nom]	Case=Nom|Degree=Pos|Number=Plur	O
 gazdag	gazdag	ADJ	[/Adj][Nom]	Case=Nom|Degree=Pos|Number=Sing	O


### PR DESCRIPTION
NER IOB labels of words "Urál" and "hegységben" in `huwiki_47.conllup` were swapped. This commit improves on this particular data error.